### PR TITLE
Fix loading of .env for local model

### DIFF
--- a/util/llm_factory.py
+++ b/util/llm_factory.py
@@ -66,11 +66,12 @@ class LLMFactory:
         """
         Creates and returns an instance of the appropriate LLM.
         """
+        load_dotenv(override=True)
         if local_llm:
             # If local_llm is True, use the local LLM instance.
             return ChatOllama(
                 model=constants.local_llm,  # Use exact model name from 'ollama list'
-                base_url=os.getenv("local_model_url"),  # Ollama server URL
+                base_url=os.getenv("local_model_url", "http://localhost:11434"),  # Ollama server URL
             )
         model_name = LLMFactory.get_model_name()
         api_key = LLMFactory.get_api_key()


### PR DESCRIPTION
## Summary
- load `.env` when creating a local ChatOllama instance
- provide default Ollama base URL if `local_model_url` is unset

## Testing
- `flake8`
- `python -m py_compile util/llm_factory.py`
- `python test_run.py` *(fails: ValueError due to missing llm_provider)*
- `python - <<'PY' ...` *(fails: connection refused because local server not running)*

------
https://chatgpt.com/codex/tasks/task_e_6844ba3bef448328a7878fb22e5bee8e